### PR TITLE
fix: prevent boost:update ParseError on literal <?xml in core guideline

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -8,7 +8,9 @@ After installing via `composer require artisanpack-ui/code-style --dev`, create 
 
 @verbatim
 <code-snippet name="Basic phpcs.xml configuration" lang="xml">
-<?xml version="1.0"?>
+@endverbatim
+<{!! '?xml version="1.0"?>' !!}
+@verbatim
 <ruleset name="ProjectStandard">
     <description>Project coding standard</description>
 

--- a/tests/Feature/BoostGuidelinesCompilationTest.php
+++ b/tests/Feature/BoostGuidelinesCompilationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+
+/**
+ * Regression test for the boost guideline blade files.
+ *
+ * Ensures every file under resources/boost/guidelines/ compiles via Blade
+ * and that the resulting PHP parses cleanly even with short_open_tag enabled.
+ * Prevents the class of bug where a literal `<?xml` (or any other `<?` token)
+ * inside a code snippet gets executed as a PHP open tag by consumer apps
+ * running `boost:update`.
+ */
+$guidelinesDir = __DIR__ . '/../../resources/boost/guidelines';
+$bladeFiles    = glob($guidelinesDir . '/*.blade.php') ?: [];
+
+it('has at least one boost guideline blade file', function () use ($bladeFiles) {
+	expect($bladeFiles)->not->toBeEmpty();
+});
+
+it('compiles boost guideline blade files without producing a PHP parse error under short_open_tag=On', function (string $bladePath) {
+	$cacheDir = sys_get_temp_dir() . '/artisanpack-code-style-boost-tests-' . bin2hex(random_bytes(4));
+	mkdir($cacheDir, 0777, true);
+
+	try {
+		$compiler = new BladeCompiler(new Filesystem(), $cacheDir);
+		$compiled = $compiler->compileString(file_get_contents($bladePath));
+
+		$tmpFile = $cacheDir . '/compiled.php';
+		file_put_contents($tmpFile, $compiled);
+
+		$output = [];
+		$status = 0;
+		exec(sprintf('php -d short_open_tag=On -l %s 2>&1', escapeshellarg($tmpFile)), $output, $status);
+
+		expect($status)->toBe(0, sprintf(
+			"Compiled blade for %s failed to parse:\n%s\n\nCompiled output:\n%s",
+			basename($bladePath),
+			implode("\n", $output),
+			$compiled
+		));
+	} finally {
+		array_map('unlink', glob($cacheDir . '/*') ?: []);
+		@rmdir($cacheDir);
+	}
+})->with($bladeFiles);


### PR DESCRIPTION
## Description

`resources/boost/guidelines/core.blade.php` contained a literal `<?xml version="1.0"?>` inside an `@verbatim` block. `@verbatim` only suppresses Blade directives during compilation — it does not escape the resulting PHP source. With `short_open_tag=On`, PHP tokenizes `<?xml` as a short open tag plus the identifier `xml`, producing a `ParseError` whenever a consumer app runs `boost:update`.

The fix moves the `<?xml ...?>` line out of `@verbatim` and emits the leading `?xml version="1.0"?>` via Blade `{!! !!}`, so PHP never sees a `<?` token at parse time. The rendered guideline content is unchanged — consumers still see a usable `phpcs.xml` example with the literal XML declaration.

**Closes:** #23

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #23

## Motivation and Context

`boost:update` runs as a `post-update-cmd` after `composer update` in any Laravel app that requires `laravel/boost`. It walks every installed package's `resources/boost/guidelines/` directory and compiles each blade file. This bug caused every `composer update` in any consumer app to fail noisily, regardless of which package was actually being updated.

## Changes Made

- `resources/boost/guidelines/core.blade.php`: split the `@verbatim` block around the `<?xml` line and emit the `?xml ...?>` portion via `{!! !!}` so the compiled view never contains a `<?` token outside a proper PHP open tag.
- `tests/Feature/BoostGuidelinesCompilationTest.php`: new regression test that compiles every `resources/boost/guidelines/*.blade.php` via `BladeCompiler::compileString()` and runs `php -l` against the compiled output under `short_open_tag=On`. Catches this class of bug for any future guideline file.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0), Laravel Herd
- PHP Version: 8.4 (`short_open_tag=On`)
- Project Version: `artisanpack-ui/code-style` `release/1.1.1`

**Tests Performed:**
1. Verified the new regression test fails against the un-fixed `core.blade.php` (parse error caught).
2. Verified the new regression test passes after the fix.
3. Verified the rendered guideline output preserves the literal `<?xml version="1.0"?>` line.
4. Ran the full Pest suite — 4/4 passing.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — this is a PHP/Blade parse-time fix in a guideline file consumed by Laravel Boost; no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** Added `tests/Feature/BoostGuidelinesCompilationTest.php` covering every blade file under `resources/boost/guidelines/`.

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** No documentation changes — the rendered guideline content is unchanged for consumers.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed code snippet formatting to correctly display XML declarations in guidelines.
* **Tests**
  * Added automated verification tests to ensure all guideline templates compile correctly and parse cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->