### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ArtisanPack UI Code Style
 
+## [1.1.1] - 2026-06-05
+### Fixed
+* Prevented `boost:update` ParseError caused by a literal `<?xml` declaration in the core Boost guideline by escaping the opening PHP tag in the rendered snippet (#24, closes #23).
+
 ## [1.1.0] - 2025-11-22
 ### Added
 * Added support for Laravel Boost.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A custom PHP code style standard based on PHPStorm settings. This package provides custom sniffs for PHP_CodeSniffer that enforce consistent code style across your PHP projects.",
   "type": "phpcodesniffer-standard",
   "license": "GPL-3.0-or-later",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\sniffs\\": "src/ArtisanPackUI/Sniffs/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d58428bb9b292cd5551dc3ee8ac56bc",
+    "content-hash": "190ddef9c04c447d0db9918fc5581f41",
     "packages": [
         {
             "name": "brick/math",
@@ -8483,5 +8483,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -8,9 +8,7 @@ After installing via `composer require artisanpack-ui/code-style --dev`, create 
 
 @verbatim
 <code-snippet name="Basic phpcs.xml configuration" lang="xml">
-@endverbatim
-<{!! '?xml version="1.0"?>' !!}
-@verbatim
+&lt;?xml version="1.0"?>
 <ruleset name="ProjectStandard">
     <description>Project coding standard</description>
 

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -8,7 +8,9 @@ After installing via `composer require artisanpack-ui/code-style --dev`, create 
 
 @verbatim
 <code-snippet name="Basic phpcs.xml configuration" lang="xml">
-<?xml version="1.0"?>
+@endverbatim
+<{!! '?xml version="1.0"?>' !!}
+@verbatim
 <ruleset name="ProjectStandard">
     <description>Project coding standard</description>
 

--- a/tests/Feature/BoostGuidelinesCompilationTest.php
+++ b/tests/Feature/BoostGuidelinesCompilationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+
+/**
+ * Regression test for the boost guideline blade files.
+ *
+ * Ensures every file under resources/boost/guidelines/ compiles via Blade
+ * and that the resulting PHP parses cleanly even with short_open_tag enabled.
+ * Prevents the class of bug where a literal `<?xml` (or any other `<?` token)
+ * inside a code snippet gets executed as a PHP open tag by consumer apps
+ * running `boost:update`.
+ */
+$guidelinesDir = __DIR__ . '/../../resources/boost/guidelines';
+$bladeFiles    = glob($guidelinesDir . '/*.blade.php') ?: [];
+
+it('has at least one boost guideline blade file', function () use ($bladeFiles) {
+	expect($bladeFiles)->not->toBeEmpty();
+});
+
+it('compiles boost guideline blade files without producing a PHP parse error under short_open_tag=On', function (string $bladePath) {
+	$cacheDir = sys_get_temp_dir() . '/artisanpack-code-style-boost-tests-' . bin2hex(random_bytes(4));
+	mkdir($cacheDir, 0777, true);
+
+	try {
+		$compiler = new BladeCompiler(new Filesystem(), $cacheDir);
+		$compiled = $compiler->compileString(file_get_contents($bladePath));
+
+		$tmpFile = $cacheDir . '/compiled.php';
+		file_put_contents($tmpFile, $compiled);
+
+		$output = [];
+		$status = 0;
+		exec(sprintf('php -d short_open_tag=On -l %s 2>&1', escapeshellarg($tmpFile)), $output, $status);
+
+		expect($status)->toBe(0, sprintf(
+			"Compiled blade for %s failed to parse:\n%s\n\nCompiled output:\n%s",
+			basename($bladePath),
+			implode("\n", $output),
+			$compiled
+		));
+	} finally {
+		array_map('unlink', glob($cacheDir . '/*') ?: []);
+		@rmdir($cacheDir);
+	}
+})->with($bladeFiles);

--- a/tests/Feature/BoostGuidelinesCompilationTest.php
+++ b/tests/Feature/BoostGuidelinesCompilationTest.php
@@ -32,6 +32,7 @@ it('compiles boost guideline blade files without producing a PHP parse error und
 
 		$output = [];
 		$status = 0;
+		// nosemgrep: php.lang.security.command-injection.command-injection
 		exec(sprintf('php -d short_open_tag=On -l %s 2>&1', escapeshellarg($tmpFile)), $output, $status);
 
 		expect($status)->toBe(0, sprintf(


### PR DESCRIPTION
<!--- Title format: Release v1.0.0 -->


## Release Information

- **Release Version:** v1.1.1
- **Release Date:** 2026-06-05
- **Release Type:** Patch
- **Release Branch:** `release/1.1.1`
- **Target Branch:** `main`

## Release Summary

Patch release that fixes a `boost:update` ParseError caused by a literal `<?xml` declaration inside the core Boost guideline snippet. When Laravel Boost compiled the published guideline blade file, the embedded `<?xml` token was treated as a PHP open tag and tripped a parse error in consumer apps. The opening tag is now escaped in the rendered output and a regression test guards the entire `resources/boost/guidelines/` directory against the same class of bug.

## Changelog

### Added
- 

### Changed
- 

### Deprecated
- 

### Removed
- 

### Fixed
- Prevented `boost:update` ParseError caused by a literal `<?xml` declaration in the core Boost guideline by escaping the opening PHP tag in the rendered snippet.

### Security
- 

## Issues and Pull Requests

**Issues Fixed:**
- Closes #23

**Related PRs:**
- #24

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:**

n/a

**Migration guide:**

n/a

## Testing Checklist

- [x] All automated tests passing (4 tests, 4 assertions)
- [x] Manual testing completed
- [ ] Accessibility tests passing
- [ ] Performance tests passing (if applicable)
- [x] Security scan completed (see Notes — transitive dev advisories only)
- [ ] Tested in staging environment
- [ ] Database migrations tested (if applicable)

**Testing notes:**

The new `BoostGuidelinesCompilationTest` compiles every blade file under `resources/boost/guidelines/` and verifies the resulting PHP parses cleanly with `short_open_tag=On`, locking down the regression that prompted this patch.

## Documentation Checklist

- [x] CHANGELOG updated
- [x] README updated (if needed)
- [x] API documentation updated (if needed)
- [ ] Migration guide written (if breaking changes)
- [x] Release notes written
- [ ] Wiki updated (if applicable)

## Pre-Release Checklist

- [x] Version number updated in all necessary files
- [ ] Git tag prepared: `v1.1.1`
- [x] Release branch created/updated: `release/1.1.1`
- [x] Dependencies updated and tested
- [x] Build artifacts generated
- [x] Deployment plan reviewed
- [x] Rollback plan prepared
- [ ] Stakeholders notified

## Deployment

**Deployment steps:**
1. Merge this PR into `main`
2. Tag `v1.1.1` on `main`
3. Push the tag so Packagist picks up the new release

**Rollback plan:**
1. Revert the merge commit on `main`
2. Re-tag `v1.1.0` if Packagist needs to roll back

**Configuration changes:**
- None

**Environment variables:**
- None

## Post-Release Tasks

- [ ] Tag created: `v1.1.1`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

**Dependency audit:** `composer audit` reports 13 advisories across 9 packages (3 high, 6 medium, 1 low, 3 unspecified). All of them sit in transitive dependencies pulled in by `pestphp/pest` / `pestphp/pest-plugin-laravel` for the dev test environment (`laravel/framework`, `symfony/*`, `league/commonmark`, `phpunit/phpunit`). They do not affect the runtime surface this package ships, but the dev test stack is due for a refresh in a future release.

**Outdated direct dev dependencies** (no action this release):
- `pestphp/pest` 3.8.2 → 4.7.2 (major)
- `pestphp/pest-plugin-laravel` 3.2.0 → 4.1.0 (major)
- `squizlabs/php_codesniffer` 3.13.0 → 4.0.1 (major)

---

**Release Manager:** @ViewFromTheBox
**Reviewers Required:** @ViewFromTheBox

**For Reviewers:**
- Verify all checklist items completed
- Review changelog accuracy
- Confirm version numbers correct
- Check breaking changes documented
- Approve deployment plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Escaped an XML declaration in the Boost guideline documentation to prevent template rendering and parse errors.

* **Tests**
  * Added regression tests to ensure guideline templates compile and parse cleanly under relevant PHP settings.

* **Chores**
  * Bumped package release to 1.1.1 and added a corresponding changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->